### PR TITLE
Bump version of Publishers

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ docbookVersion=5.2b08
 defguideBookVersion=5.2.5
 defguideRnd=src/lib/defguide.rnd
 
-publishersBookVersion=1.3.0
+publishersBookVersion=1.3.1
 publishersRnd=src/lib/publishers.rnd
 
 sdocbookBookVersion=0.9.0


### PR DESCRIPTION
Nudged the version of DocBook Publishers: TDG because I realize I did edit a couple of the Publishers reference pages when I was cleaning up FIXME:s.