### PR TITLE
Typo in example

### DIFF
--- a/en/refpages/examples/videoobject.3.xml
+++ b/en/refpages/examples/videoobject.3.xml
@@ -7,7 +7,7 @@
       <multimediaparam name="type" value="video/ogg"/>
     </videodata>
     <videodata fileref='movie.mp4' autoplay="true" classid="com.example.player">
-      <multimediaparam name="type" value="vidoe/mp4"/>
+      <multimediaparam name="type" value="video/mp4"/>
     </videodata>
     <videodata fileref='movie.webm' autoplay="true" classid="com.example.player">
       <multimediaparam name="type" value="video/webm"/>


### PR DESCRIPTION
I'm not sure what's the best place for this PR: the 5.2 branch still has this typo (https://github.com/docbook/defguide/blob/docbook-5.2/src/refpages/examples/videoobject.3.xml).